### PR TITLE
remove --mode=global as they can't be scaled down

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Create a service and enter your bitcoin wallet ID:
 * Mine Hodl
 
 ```
-docker service create --mode=global \
+docker service create \
   --name miner alexellis2/cpu-opt:2018-1-2 ./cpuminer \
   -a hodl \
   -o stratum+tcp://hodl.usa.nicehash.com:3352 \
@@ -80,7 +80,7 @@ docker service create --mode=global \
 * Mine Cryptonight
 
 ```
-docker service create --mode=global \
+docker service create \
   --name miner alexellis2/cpu-opt:2018-1-2 ./cpuminer \
   -a cryptonight \
   -o stratum+tcp://cryptonight.usa.nicehash.com:3355 \


### PR DESCRIPTION
When creating the service with --mode=global, the service can't be scaled down to 0 in the following step.